### PR TITLE
CYTHINF-26 Remove RuntimeIdentifier Config

### DIFF
--- a/src/BuildTasks/BuildTasks.csproj
+++ b/src/BuildTasks/BuildTasks.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>Cythral.CloudFormation.BuildTasks</AssemblyName>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Core/CoreTests.csproj
+++ b/tests/Core/CoreTests.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This was added as an attempted fix to get the app to build on my machine.  I have instead added arch-x64 to the runtime identifier graph locally to workaround my issue.