### PR TITLE
Fix Analyzer Exception

### DIFF
--- a/src/CustomResource/CustomResource.csproj
+++ b/src/CustomResource/CustomResource.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="AWSSDK.Core" Version="3.3.103.52" />
     <PackageReference Include="GitInfo" Version="2.0.20" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0" />
     <PackageReference Include="Cythral.CodeGeneration.Roslyn" Version="0.7.10" PrivateAssets="none" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />


### PR DESCRIPTION
CSC : warning AD0001: Analyzer 'Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.CSharpDiagnosticAnalyzerApiUsageAnalyzer' threw an exception of type 'NullReferenceException'

Microsoft.CodeAnalysis.Analyzers appears to be a peer dependency of the Microsoft.CodeAnalysis.CSharp dependency that Cythral.CloudFormation.CustomResource adds in. 