### PR TITLE
CYTHINF-27 Cross-Account Certificate Validation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Core/bin/Debug/netcoreapp3.0/bootstrap.dll",
+            "program": "dotnet test",
             "args": [],
-            "cwd": "${workspaceFolder}/src/Core",
+            "cwd": "${workspaceFolder}/tests/Resources",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,9 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/src/Core/Core.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "${workspaceFolder}/tests/Resources/ResourcesTests.csproj"
             ],
             "problemMatcher": "$msCompile"
         },

--- a/src/CustomResource/Generator.cs
+++ b/src/CustomResource/Generator.cs
@@ -351,6 +351,7 @@ namespace Cythral.CloudFormation.CustomResource
             yield return ParseStatement($"var request = await System.Text.Json.JsonSerializer.DeserializeAsync<Request<{ResourcePropertiesTypeName}>>(stream, SerializerOptions);");
             yield return ParseStatement("Console.WriteLine($\"Received request: {System.Text.Json.JsonSerializer.Serialize(request, SerializerOptions)}\");");
             yield return ParseStatement("resource.Request = request;");
+            yield return ParseStatement("resource.PhysicalResourceId = request?.PhysicalResourceId;");
 
             var cases = new List<SwitchSectionSyntax> {
                 GenerateHandleMethodCreateCase(),

--- a/src/Resources/Factories/AcmFactory.cs
+++ b/src/Resources/Factories/AcmFactory.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+using Amazon.CertificateManager;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public class AcmFactory : IAcmFactory
+    {
+        public Task<IAmazonCertificateManager> Create()
+        {
+            return Task.FromResult((IAmazonCertificateManager)new AmazonCertificateManagerClient());
+        }
+    }
+}

--- a/src/Resources/Factories/IAcmFactory.cs
+++ b/src/Resources/Factories/IAcmFactory.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+using Amazon.CertificateManager;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public interface IAcmFactory
+    {
+        Task<IAmazonCertificateManager> Create();
+    }
+}

--- a/src/Resources/Factories/ILambdaFactory.cs
+++ b/src/Resources/Factories/ILambdaFactory.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+using Amazon.Lambda;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public interface ILambdaFactory
+    {
+        Task<IAmazonLambda> Create();
+    }
+}

--- a/src/Resources/Factories/IRoute53Factory.cs
+++ b/src/Resources/Factories/IRoute53Factory.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+using Amazon.Route53;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public interface IRoute53Factory
+    {
+        Task<IAmazonRoute53> Create(string roleArn = null);
+    }
+}

--- a/src/Resources/Factories/IStsFactory.cs
+++ b/src/Resources/Factories/IStsFactory.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+using Amazon.SecurityToken;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public interface IStsFactory
+    {
+        Task<IAmazonSecurityTokenService> Create();
+    }
+}

--- a/src/Resources/Factories/LambdaFactory.cs
+++ b/src/Resources/Factories/LambdaFactory.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+using Amazon.Lambda;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public class LambdaFactory : ILambdaFactory
+    {
+        public Task<IAmazonLambda> Create()
+        {
+            return Task.FromResult((IAmazonLambda)new AmazonLambdaClient());
+        }
+    }
+}

--- a/src/Resources/Factories/Route53Factory.cs
+++ b/src/Resources/Factories/Route53Factory.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+
+using Amazon.Runtime;
+using Amazon.Route53;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public class Route53Factory : IRoute53Factory
+    {
+
+        private IStsFactory _stsFactory { get; set; } = new StsFactory();
+
+        public async Task<IAmazonRoute53> Create(string roleArn = null)
+        {
+            if (roleArn != null)
+            {
+                var stsClient = await _stsFactory.Create();
+                var response = await stsClient.AssumeRoleAsync(new AssumeRoleRequest
+                {
+                    RoleArn = roleArn,
+                    RoleSessionName = "route-53-operations"
+                });
+
+                return new AmazonRoute53Client(response.Credentials);
+            }
+
+            return new AmazonRoute53Client();
+        }
+    }
+}

--- a/src/Resources/Factories/StsFactory.cs
+++ b/src/Resources/Factories/StsFactory.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+using Amazon.SecurityToken;
+
+namespace Cythral.CloudFormation.Resources.Factories
+{
+    public class StsFactory : IStsFactory
+    {
+        public Task<IAmazonSecurityTokenService> Create()
+        {
+            return Task.FromResult((IAmazonSecurityTokenService)new AmazonSecurityTokenServiceClient());
+        }
+    }
+}

--- a/src/Resources/Resources.csproj
+++ b/src/Resources/Resources.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.101.80" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.3.103.19" />
     <PackageReference Include="AWSSDK.Route53" Version="3.3.102.33" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.104.15" />
     <ProjectReference Include="..\CustomResource\CustomResource.csproj" />
   </ItemGroup>
 

--- a/tests/Resources/Factories/AcmFactoryTest.cs
+++ b/tests/Resources/Factories/AcmFactoryTest.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Cythral.CloudFormation.Resources.Factories.Tests
+{
+    public class AcmFactoryTest
+    {
+        [Test]
+        public async Task Create_DoesNotReturnNull()
+        {
+            var factory = new AcmFactory();
+            var result = await factory.Create();
+
+            Assert.That(result, Is.Not.EqualTo(null));
+        }
+    }
+}

--- a/tests/Resources/Factories/LambdaFactory.cs
+++ b/tests/Resources/Factories/LambdaFactory.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Cythral.CloudFormation.Resources.Factories.Tests
+{
+    public class LambdaFactoryTest
+    {
+        [Test]
+        public async Task Create_DoesNotReturnNull()
+        {
+            var factory = new LambdaFactory();
+            var result = await factory.Create();
+
+            Assert.That(result, Is.Not.EqualTo(null));
+        }
+    }
+}

--- a/tests/Resources/Factories/Route53FactoryTest.cs
+++ b/tests/Resources/Factories/Route53FactoryTest.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+
+using Amazon.Runtime;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+
+using Cythral.CloudFormation.Resources.Tests;
+using static Cythral.CloudFormation.Resources.Tests.TestUtils;
+
+using NSubstitute;
+
+using NUnit.Framework;
+
+namespace Cythral.CloudFormation.Resources.Factories.Tests
+{
+    public class Route53FactoryTest
+    {
+
+        private static IStsFactory StsFactory = Substitute.For<IStsFactory>();
+        private static IAmazonSecurityTokenService StsClient = Substitute.For<IAmazonSecurityTokenService>();
+
+        private static Route53Factory CreateInstance()
+        {
+            var instance = new Route53Factory();
+            SetPrivateProperty(instance, "_stsFactory", StsFactory);
+            return instance;
+        }
+
+        [SetUp]
+        public void SetUpStsFactory()
+        {
+            StsFactory.ClearReceivedCalls();
+            StsFactory.Create().Returns(StsClient);
+        }
+
+        [SetUp]
+        public void SetUpStsClient()
+        {
+            StsClient.ClearReceivedCalls();
+            StsClient.AssumeRoleAsync(Arg.Any<AssumeRoleRequest>()).Returns(new AssumeRoleResponse());
+        }
+
+        [Test]
+        public async Task CreateWithNoArgs_DoesNotReturnNull()
+        {
+            var instance = CreateInstance();
+            var result = await instance.Create();
+
+            Assert.That(result, Is.Not.EqualTo(null));
+        }
+
+        [Test]
+        public async Task CreateWithNoArgs_DoesAssumeRole()
+        {
+            var instance = CreateInstance();
+            await instance.Create();
+
+            await StsFactory.DidNotReceive().Create();
+        }
+
+        [Test]
+        public async Task CreateWithRoleArn_CreatesClientWithCredentials()
+        {
+            var roleArn = "test arn";
+            var instance = CreateInstance();
+            var credentials = new SessionAWSCredentials("key", "secret", "token");
+
+            StsClient.AssumeRoleAsync(Arg.Any<AssumeRoleRequest>()).Returns(new AssumeRoleResponse
+            {
+                Credentials = new Credentials
+                {
+                    AccessKeyId = credentials.GetCredentials().AccessKey,
+                    SecretAccessKey = credentials.GetCredentials().SecretKey,
+                    SessionToken = credentials.GetCredentials().Token,
+                }
+            });
+
+            var result = await instance.Create(roleArn);
+            await StsFactory.Received().Create();
+            await StsClient.Received().AssumeRoleAsync(
+                Arg.Is<AssumeRoleRequest>(req => req.RoleArn == roleArn && req.RoleSessionName != null)
+            );
+
+            TestUtils.AssertClientHasCredentials((AmazonServiceClient)result, credentials);
+        }
+    }
+}

--- a/tests/Resources/Factories/StsFactoryTest.cs
+++ b/tests/Resources/Factories/StsFactoryTest.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Cythral.CloudFormation.Resources.Factories.Tests
+{
+    public class StsFactoryTest
+    {
+        [Test]
+        public async Task Create_DoesNotReturnNull()
+        {
+            var factory = new StsFactory();
+            var result = await factory.Create();
+
+            Assert.That(result, Is.Not.EqualTo(null));
+        }
+    }
+}

--- a/tests/Resources/TestUtils.cs
+++ b/tests/Resources/TestUtils.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+
+using Amazon.Runtime;
+
+namespace Cythral.CloudFormation.Resources.Tests
+{
+    public class TestUtils
+    {
+        public static void AssertClientHasCredentials(AmazonServiceClient client, AWSCredentials credentials)
+        {
+            var prop = client.GetType().GetProperty("Credentials", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            var actualCredentials = ((AWSCredentials)prop.GetValue(client)).GetCredentials();
+            var givenCredentials = credentials.GetCredentials();
+
+            if (actualCredentials?.AccessKey != givenCredentials.AccessKey ||
+                actualCredentials?.SecretKey != givenCredentials.SecretKey ||
+                actualCredentials?.Token != givenCredentials.Token)
+            {
+                throw new Exception("Credentials do not match");
+            }
+        }
+
+        public static void SetPrivateProperty<T, U>(T target, string name, U value) {
+            var prop = target.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            prop.SetValue(target, value);
+        }
+
+
+        public static void SetReadonlyField<T, U>(T target, string name, U value) {
+            var field = target.GetType().GetField(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            field.SetValue(target, value);
+        }
+    }
+}


### PR DESCRIPTION
* Added Factory classes for Route53, ACM, and Lambda Clients
* Updated Certificate CR to use the new factory classes as private properties
* Setting private properties via reflection during tests only
* Refactored Certificate tests to call Create/Wait/Update/Delete directly instead of Handle - Handle functionality is tested in CustomResource proj