### PR TITLE
CYTHINF-27 Add CreationRoleArn Property to Certificate Resource

### DIFF
--- a/src/Resources/Factories/AcmFactory.cs
+++ b/src/Resources/Factories/AcmFactory.cs
@@ -1,14 +1,30 @@
 using System.Threading.Tasks;
 
 using Amazon.CertificateManager;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
 
 namespace Cythral.CloudFormation.Resources.Factories
 {
     public class AcmFactory : IAcmFactory
     {
-        public Task<IAmazonCertificateManager> Create()
+        private IStsFactory _stsFactory { get; set; } = new StsFactory();
+
+        public async Task<IAmazonCertificateManager> Create(string roleArn = null)
         {
-            return Task.FromResult((IAmazonCertificateManager)new AmazonCertificateManagerClient());
+            if (roleArn != null)
+            {
+                var stsClient = await _stsFactory.Create();
+                var response = await stsClient.AssumeRoleAsync(new AssumeRoleRequest
+                {
+                    RoleArn = roleArn,
+                    RoleSessionName = "acm-operations"
+                });
+
+                return new AmazonCertificateManagerClient(response.Credentials);
+            }
+
+            return new AmazonCertificateManagerClient();
         }
     }
 }

--- a/src/Resources/Factories/IAcmFactory.cs
+++ b/src/Resources/Factories/IAcmFactory.cs
@@ -6,6 +6,6 @@ namespace Cythral.CloudFormation.Resources.Factories
 {
     public interface IAcmFactory
     {
-        Task<IAmazonCertificateManager> Create();
+        Task<IAmazonCertificateManager> Create(string roleArn = null);
     }
 }

--- a/tests/Resources/CertificateTest.cs
+++ b/tests/Resources/CertificateTest.cs
@@ -149,7 +149,7 @@ namespace Tests
         {
             var factory = Substitute.For<IAcmFactory>();
             client = client ?? CreateAcmClient();
-            factory.Create().Returns(client);
+            factory.Create(Arg.Any<string>()).Returns(client);
             return factory;
         }
 
@@ -304,6 +304,21 @@ namespace Tests
         }
 
         [Test]
+        public async Task Create_WithCreationRoleArn_CallsCreateAcmFactoryWithRoleArn()
+        {
+            IAcmFactory acmFactory;
+            IRoute53Factory route53Factory;
+            ILambdaFactory lambdaFactory;
+
+            var instance = CreateInstance(out acmFactory, out route53Factory, out lambdaFactory);
+            var roleArn = "arn";
+            instance.Request.ResourceProperties.CreationRoleArn = roleArn;
+
+            await instance.Create();
+            await acmFactory.Received().Create(Arg.Is<string>(val => val == roleArn));
+        }
+
+        [Test]
         public async Task Create_WithValidationRoleArn_CallsCreateRoute53FactoryWithRoleArn()
         {
             IAcmFactory acmFactory;
@@ -316,6 +331,21 @@ namespace Tests
 
             await instance.Create();
             await route53Factory.Received().Create(Arg.Is<string>(val => val == roleArn));
+        }
+
+        [Test]
+        public async Task Wait_WithCreationRoleArn_CallsCreateAcmFactoryWithRoleArn()
+        {
+            IAcmFactory acmFactory;
+            IRoute53Factory route53Factory;
+            ILambdaFactory lambdaFactory;
+
+            var instance = CreateInstance(out acmFactory, out route53Factory, out lambdaFactory);
+            var roleArn = "arn";
+            instance.Request.ResourceProperties.CreationRoleArn = roleArn;
+
+            await instance.Wait();
+            await acmFactory.Received().Create(Arg.Is<string>(val => val == roleArn));
         }
 
         [Test]
@@ -381,6 +411,20 @@ namespace Tests
             Assert.ThrowsAsync<Exception>(async () => await instance.Wait());
         }
 
+        [Test]
+        public async Task Update_WithCreationRoleArn_CallsCreateAcmFactoryWithRoleArn()
+        {
+            IAcmFactory acmFactory;
+            IRoute53Factory route53Factory;
+            ILambdaFactory lambdaFactory;
+
+            var instance = CreateInstance(out acmFactory, out route53Factory, out lambdaFactory);
+            var roleArn = "arn";
+            instance.Request.ResourceProperties.CreationRoleArn = roleArn;
+
+            await instance.Update();
+            await acmFactory.Received().Create(Arg.Is<string>(val => val == roleArn));
+        }
 
         [Test]
         public async Task Update_CallsAddAndDeleteTags()
@@ -436,6 +480,21 @@ namespace Tests
                 req.CertificateArn == ARN &&
                 req.Options.CertificateTransparencyLoggingPreference == CertificateTransparencyLoggingPreference.ENABLED
             ));
+        }
+
+        [Test]
+        public async Task Delete_WithCreationRoleArn_CallsCreateAcmFactoryWithRoleArn()
+        {
+            IAcmFactory acmFactory;
+            IRoute53Factory route53Factory;
+            ILambdaFactory lambdaFactory;
+
+            var instance = CreateInstance(out acmFactory, out route53Factory, out lambdaFactory);
+            var roleArn = "arn";
+            instance.Request.ResourceProperties.CreationRoleArn = roleArn;
+
+            await instance.Delete();
+            await acmFactory.Received().Create(Arg.Is<string>(val => val == roleArn));
         }
 
         [Test]

--- a/tests/Resources/Factories/AcmFactoryTest.cs
+++ b/tests/Resources/Factories/AcmFactoryTest.cs
@@ -1,18 +1,88 @@
+using System;
 using System.Threading.Tasks;
 
+using Amazon.Runtime;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+
+using Cythral.CloudFormation.Resources.Tests;
+using static Cythral.CloudFormation.Resources.Tests.TestUtils;
+
+using NSubstitute;
+
 using NUnit.Framework;
+
 
 namespace Cythral.CloudFormation.Resources.Factories.Tests
 {
     public class AcmFactoryTest
     {
-        [Test]
-        public async Task Create_DoesNotReturnNull()
+        private static IStsFactory StsFactory = Substitute.For<IStsFactory>();
+        private static IAmazonSecurityTokenService StsClient = Substitute.For<IAmazonSecurityTokenService>();
+
+        private static AcmFactory CreateInstance()
         {
-            var factory = new AcmFactory();
-            var result = await factory.Create();
+            var instance = new AcmFactory();
+            SetPrivateProperty(instance, "_stsFactory", StsFactory);
+            return instance;
+        }
+
+        [SetUp]
+        public void SetUpStsFactory()
+        {
+            StsFactory.ClearReceivedCalls();
+            StsFactory.Create().Returns(StsClient);
+        }
+
+        [SetUp]
+        public void SetUpStsClient()
+        {
+            StsClient.ClearReceivedCalls();
+            StsClient.AssumeRoleAsync(Arg.Any<AssumeRoleRequest>()).Returns(new AssumeRoleResponse());
+        }
+
+        [Test]
+        public async Task CreateWithNoArgs_DoesNotReturnNull()
+        {
+            var instance = CreateInstance();
+            var result = await instance.Create();
 
             Assert.That(result, Is.Not.EqualTo(null));
+        }
+
+        [Test]
+        public async Task CreateWithNoArgs_DoesAssumeRole()
+        {
+            var instance = CreateInstance();
+            await instance.Create();
+
+            await StsFactory.DidNotReceive().Create();
+        }
+
+        [Test]
+        public async Task CreateWithRoleArn_CreatesClientWithCredentials()
+        {
+            var roleArn = "test arn";
+            var instance = CreateInstance();
+            var credentials = new SessionAWSCredentials("key", "secret", "token");
+
+            StsClient.AssumeRoleAsync(Arg.Any<AssumeRoleRequest>()).Returns(new AssumeRoleResponse
+            {
+                Credentials = new Credentials
+                {
+                    AccessKeyId = credentials.GetCredentials().AccessKey,
+                    SecretAccessKey = credentials.GetCredentials().SecretKey,
+                    SessionToken = credentials.GetCredentials().Token,
+                }
+            });
+
+            var result = await instance.Create(roleArn);
+            await StsFactory.Received().Create();
+            await StsClient.Received().AssumeRoleAsync(
+                Arg.Is<AssumeRoleRequest>(req => req.RoleArn == roleArn && req.RoleSessionName != null)
+            );
+
+            TestUtils.AssertClientHasCredentials((AmazonServiceClient)result, credentials);
         }
     }
 }


### PR DESCRIPTION
* Adds a property to the certificate custom resource that you can use to control what role is used when performing ACM operations (create certificate, add tags to certificate, etc.)