### PR TITLE
CYTHINF-27 Add missing using stmt

### DIFF
--- a/src/Resources/Certificate.cs
+++ b/src/Resources/Certificate.cs
@@ -16,6 +16,7 @@ using Amazon.Route53.Model;
 using Cythral.CloudFormation.CustomResource;
 using Cythral.CloudFormation.CustomResource.Attributes;
 using Cythral.CloudFormation.Resources.Factories;
+using static Cythral.CloudFormation.CustomResource.GranteeType;
 
 using static Amazon.Route53.ChangeStatus;
 


### PR DESCRIPTION
Adds a static using stmt in the Certificate Custom Resource - GranteeType needed for the custom resource attribute args.