### PR TITLE
CYTHINF-64 Add AssemblyInfo

### DIFF
--- a/src/Core/AssemblyInfo.cs
+++ b/src/Core/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly:Amazon.Lambda.Core.LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]


### PR DESCRIPTION
This adds the lambda serializer assembly attribute back to the core assembly