### PR TITLE
CYTHINF-122 Hotfix - Create S3 Client with RoleArn

### DIFF
--- a/src/Core/S3Deployment/Handler.cs
+++ b/src/Core/S3Deployment/Handler.cs
@@ -37,7 +37,7 @@ namespace Cythral.CloudFormation.S3Deployment
 
             try
             {
-                await MarkExistingObjectsAsDirty(request.DestinationBucket);
+                await MarkExistingObjectsAsDirty(request.RoleArn, request.DestinationBucket);
 
                 using (var stream = await s3GetObjectFacade.GetObjectStream(request.ZipLocation))
                 using (var zipStream = new ZipArchive(stream))
@@ -64,9 +64,9 @@ namespace Cythral.CloudFormation.S3Deployment
             };
         }
 
-        private static async Task MarkExistingObjectsAsDirty(string destinationBucket)
+        private static async Task MarkExistingObjectsAsDirty(string roleArn, string destinationBucket)
         {
-            using (var client = await s3Factory.Create())
+            using (var client = await s3Factory.Create(roleArn))
             {
                 var response = await client.ListObjectsV2Async(new ListObjectsV2Request
                 {

--- a/tests/Core/S3Deployment/HandlerTests.cs
+++ b/tests/Core/S3Deployment/HandlerTests.cs
@@ -65,7 +65,7 @@ namespace Cythral.CloudFormation.Tests.S3Deployment
             TestUtils.SetPrivateStaticField(typeof(Handler), "s3GetObjectFacade", s3GetObjectFacade);
 
             s3Factory.ClearSubstitute();
-            s3Factory.Create(Arg.Any<string>()).Returns(s3Client);
+            s3Factory.Create(Arg.Is(roleArn)).Returns(s3Client);
 
             s3Client.ClearSubstitute();
 
@@ -143,6 +143,16 @@ namespace Cythral.CloudFormation.Tests.S3Deployment
                 req.CommitState == CommitState.Pending &&
                 req.ProjectName == destinationBucket
             ));
+        }
+
+        [Test]
+        public async Task ShouldCreateClientWithRoleArn()
+        {
+            var request = CreateRequest();
+
+            await Handler.Handle(request);
+
+            await s3Factory.Received(3).Create(Arg.Is(roleArn));
         }
 
         [Test]


### PR DESCRIPTION
Fix for CYTHINF-122 - the s3 client created to list and tag objects should be created with a the RoleArn passed from the request payload