### PR TITLE
CYTHINF-122 Hotfix: Rethrow If Errored

### DIFF
--- a/src/Core/S3Deployment/Handler.cs
+++ b/src/Core/S3Deployment/Handler.cs
@@ -55,7 +55,9 @@ namespace Cythral.CloudFormation.S3Deployment
             catch (Exception e)
             {
                 Console.WriteLine($"Got an error uploading files: {e.Message} {e.StackTrace}");
+
                 await PutCommitStatus(request, CommitState.Failure);
+                throw e;
             }
 
             return new Response

--- a/tests/Core/S3Deployment/HandlerTests.cs
+++ b/tests/Core/S3Deployment/HandlerTests.cs
@@ -165,6 +165,8 @@ namespace Cythral.CloudFormation.Tests.S3Deployment
             await s3Client.Received().ListObjectsV2Async(Arg.Is<ListObjectsV2Request>(req => req.BucketName == destinationBucket));
         }
 
+
+
         [Test]
         public async Task ShouldMarkExistingObjectsAsDirty([ValueSource("existingObjectKeys")] string objectKey)
         {
@@ -290,7 +292,8 @@ namespace Cythral.CloudFormation.Tests.S3Deployment
             s3Client.PutObjectAsync(null).ReturnsForAnyArgs<PutObjectResponse>(x => { throw new Exception(); });
 
             var request = CreateRequest();
-            await Handler.Handle(request);
+
+            Assert.ThrowsAsync<Exception>(() => Handler.Handle(request));
 
             await putCommitStatusFacade.DidNotReceive().PutCommitStatus(Arg.Is<PutCommitStatusRequest>(req =>
                 req.CommitState == CommitState.Success &&
@@ -310,7 +313,8 @@ namespace Cythral.CloudFormation.Tests.S3Deployment
             s3Client.PutObjectAsync(null).ReturnsForAnyArgs<PutObjectResponse>(x => { throw new Exception(); });
 
             var request = CreateRequest();
-            await Handler.Handle(request);
+
+            Assert.ThrowsAsync<Exception>(() => Handler.Handle(request));
 
             await putCommitStatusFacade.Received().PutCommitStatus(Arg.Is<PutCommitStatusRequest>(req =>
                 req.CommitState == CommitState.Failure &&
@@ -332,7 +336,7 @@ namespace Cythral.CloudFormation.Tests.S3Deployment
             var request = CreateRequest();
             request.ProjectName = null;
 
-            await Handler.Handle(request);
+            Assert.ThrowsAsync<Exception>(() => Handler.Handle(request));
 
             await putCommitStatusFacade.Received().PutCommitStatus(Arg.Is<PutCommitStatusRequest>(req =>
                 req.CommitState == CommitState.Failure &&


### PR DESCRIPTION
Rethrow s3 deployment errors so execution of the pipeline does not continue.