### PR TITLE
S3 Deployment Thread-Safe Hotfix

### DIFF
--- a/src/Core/S3Deployment/Handler.cs
+++ b/src/Core/S3Deployment/Handler.cs
@@ -45,9 +45,12 @@ namespace Cythral.CloudFormation.S3Deployment
                     var bucket = request.DestinationBucket;
                     var role = request.RoleArn;
                     var entries = zipStream.Entries.ToList();
-                    var tasks = entries.Select(entry => UploadEntry(entry, bucket, role));
 
-                    await Task.WhenAll(tasks);
+                    // zip archive operations not thread safe
+                    foreach (var entry in entries)
+                    {
+                        await UploadEntry(entry, bucket, role);
+                    }
                 }
 
                 await PutCommitStatus(request, CommitState.Success);


### PR DESCRIPTION
Operations on `ZipArchive` are not thread safe, so upload entries 'synchronously'