### PR TITLE
Stack Deployment Status - Inject S3

### DIFF
--- a/src/Core/StackDeploymentStatus/Startup.cs
+++ b/src/Core/StackDeploymentStatus/Startup.cs
@@ -1,4 +1,5 @@
 using Amazon.CloudFormation;
+using Amazon.S3;
 using Amazon.SQS;
 using Amazon.StepFunctions;
 
@@ -18,6 +19,7 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
             services.UseAwsService<IAmazonStepFunctions>();
             services.UseAwsService<IAmazonCloudFormation>();
             services.UseAwsService<IAmazonSQS>();
+            services.UseAwsService<IAmazonS3>();
 
             services.AddSingleton<TokenInfoRepository>();
             services.AddSingleton<GithubHttpClient>();


### PR DESCRIPTION
S3 was not being injected into the container and causing issues with statuses being reported.   