### PR TITLE
Stack Deployment Statuses - Use Stack Names

### DIFF
--- a/src/Core/StackDeployment/Github/GithubStatusNotifier.cs
+++ b/src/Core/StackDeployment/Github/GithubStatusNotifier.cs
@@ -36,7 +36,7 @@ namespace Cythral.CloudFormation.StackDeployment.Github
                     State = state,
                     Description = description,
                     TargetUrl = $"https://sso.brigh.id/start/{environmentName}?destination={destination}",
-                    Context = $"AWS CloudFormation - {environmentName} ({repo})",
+                    Context = $"AWS CloudFormation - {environmentName} ({stackName})",
                 })
             });
         }

--- a/src/Core/StackDeploymentStatus/Github/GithubStatusNotifier.cs
+++ b/src/Core/StackDeploymentStatus/Github/GithubStatusNotifier.cs
@@ -36,7 +36,7 @@ namespace Cythral.CloudFormation.StackDeploymentStatus.Github
                     State = state,
                     Description = description,
                     TargetUrl = $"https://sso.brigh.id/start/{environmentName}?destination={destination}",
-                    Context = $"AWS CloudFormation - {environmentName} ({repo})",
+                    Context = $"AWS CloudFormation - {environmentName} ({stackName})",
                 })
             });
         }


### PR DESCRIPTION
Stack deployment statuses had been inadvertently set to repo names instead of stack names