### PR TITLE
GithubWebhook: Set .NET Layer Version to 2

### DIFF
--- a/src/Core/Core.template.yml
+++ b/src/Core/Core.template.yml
@@ -283,7 +283,7 @@ Resources:
       CodeUri: ../../bin/GithubWebhook/Release/net5.0/linux-x64/publish/
       MemorySize: 512
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:4
+        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:2
       Policies:
         - AWSLambdaExecute
         - !Ref GithubWebhookPolicy


### PR DESCRIPTION
Sets the .NET Layer version to 2 for the Github Webhook (layer versions inconsistent across environments)