### PR TITLE
Upgrade BuildTasks to Fix Permissions

### DIFF
--- a/src/Core/Core.proj
+++ b/src/Core/Core.proj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cythral.CloudFormation.BuildTasks" Version="0.2.2" />
+    <PackageReference Include="Cythral.CloudFormation.BuildTasks" Version="0.2.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,15 +34,15 @@
   <!-- Sets up the configuraiton file -->
   <Target Name="Configure" Condition="!Exists('$(ConfigFileName)')">
     <Exec Command="aws kms encrypt --key-id alias/SecretsKey --plaintext $(GithubToken) --query CiphertextBlob --output text" ConsoleToMsBuild="true">
-        <Output TaskParameter="ConsoleOutput" PropertyName="EncryptedGithubToken" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="EncryptedGithubToken" />
     </Exec>
 
     <Exec Command="aws kms encrypt --key-id alias/SecretsKey --plaintext $(GithubSigningSecret) --query CiphertextBlob --output text" ConsoleToMsBuild="true">
-        <Output TaskParameter="ConsoleOutput" PropertyName="EncryptedGithubSigningSecret" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="EncryptedGithubSigningSecret" />
     </Exec>
 
     <PropertyGroup>
-        <ConfigLines>
+      <ConfigLines>
 {
     "Parameters": {
         "GithubOwner": "$(GithubOwner)",
@@ -54,10 +54,10 @@
 }
         </ConfigLines>
     </PropertyGroup>
-    
+
     <WriteLinesToFile File="$(ConfigFileName)" Lines="$(ConfigLines)" Overwrite="true" />
   </Target>
-  
+
   <!-- Upload the code to S3 -->
   <Target Name="Package" AfterTargets="Publish" Condition="$(Package) == 'true'">
 
@@ -65,29 +65,18 @@
     <Copy SourceFiles="$(ConfigFile)" DestinationFiles="$([System.IO.Path]::GetDirectoryName('$(PackagedFile)'))/$(ConfigFileName)" Condition="$(PackagedFile) != ''" />
 
     <Exec Command="mktemp" ConsoleToMsBuild="true" Condition="$(PackagedFile) == ''">
-        <Output TaskParameter="ConsoleOutput" PropertyName="PackagedFile" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="PackagedFile" />
     </Exec>
 
-    <PackageTemplate
-      TemplateFile="$(TemplateFile)" 
-      PackageBucket="$(DeploymentBucket)" 
-      OutputTemplateFile="$(PackagedFile)" 
-      PackageManifestFile="$([System.IO.Path]::GetDirectoryName('$(PackagedFile)'))/package-manifest.json" 
-      Prefix="$(DeploymentBucketPrefix)" 
-    />
-    
+    <PackageTemplate TemplateFile="$(TemplateFile)" PackageBucket="$(DeploymentBucket)" OutputTemplateFile="$(PackagedFile)" PackageManifestFile="$([System.IO.Path]::GetDirectoryName('$(PackagedFile)'))/package-manifest.json" Prefix="$(DeploymentBucketPrefix)" />
+
     <PropertyGroup>
       <TemplateFile>$(PackagedFile)</TemplateFile>
     </PropertyGroup>
   </Target>
-  
+
   <!-- Deploy to CloudFormation -->
   <Target Name="Deploy" AfterTargets="Package" Condition="$(Deploy) == 'true'" DependsOnTargets="Configure">
-    <Deploy 
-      TemplateFile="$(TemplateFile)" 
-      StackName="$(StackName)" 
-      ConfigFile="$(ConfigFile)" 
-      Capabilities="CAPABILITY_IAM,CAPABILITY_AUTO_EXPAND" 
-    />
+    <Deploy TemplateFile="$(TemplateFile)" StackName="$(StackName)" ConfigFile="$(ConfigFile)" Capabilities="CAPABILITY_IAM,CAPABILITY_AUTO_EXPAND" />
   </Target>
 </Project>

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.0": {
       "Cythral.CloudFormation.BuildTasks": {
         "type": "Direct",
-        "requested": "[0.2.2, )",
-        "resolved": "0.2.2",
-        "contentHash": "OLVBWLxR0YXStbr2IMoV3NMWcWCKv1F+nXHRJU90Q7+bRWLiypg5vyRKA/w06+Ljo68rll4X1rc+067ZAX13Kw=="
+        "requested": "[0.2.3, )",
+        "resolved": "0.2.3",
+        "contentHash": "vJJBdT7ZbOBG2e+YNNM8E8yN7aribZFX+UkcWIWVmA2Ly0POqAzAS31B9vCwpB8ilo+PTg0r6vGt/c7ARfC8dw=="
       }
     }
   }


### PR DESCRIPTION
Upgrades BuildTasks to 0.2.3 to fix permissions errors when packaging templates. 