### PR TITLE
Upgrade Approval Notification to .NET 5

### DIFF
--- a/src/Core/ApprovalNotification/ApprovalNotification.csproj
+++ b/src/Core/ApprovalNotification/ApprovalNotification.csproj
@@ -1,14 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifiers>osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.0" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0" />
-    <PackageReference Include="AWSSDK.StepFunctions" Version="3.5.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.4" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.6" />
+    <PackageReference Include="AWSSDK.StepFunctions" Version="3.5.2.23" />
     <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
+    <PackageReference Include="Lambdajection.Runtime" Version="$(LambdajectionVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/ApprovalNotification/packages.lock.json
+++ b/src/Core/ApprovalNotification/packages.lock.json
@@ -1,32 +1,32 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.1": {
+    ".NETCoreApp,Version=v5.0": {
       "AWSSDK.S3": {
         "type": "Direct",
-        "requested": "[3.5.0, )",
-        "resolved": "3.5.0",
-        "contentHash": "CLlXO0FGY8CnzBJGyVrLAi4rTDYaNUzbitEZ6B7qvnVRUOG8HnWS3KU7nk/wm6fJVTpa+CSHoittUzHfZbY2+g==",
+        "requested": "[3.5.4, )",
+        "resolved": "3.5.4",
+        "contentHash": "IHaHZE5T/JQsM4+l+eHBdqPRuCfq36QpkqFn+ftLAmt1oKmdKQVOcEiE3rkMhVJiB3poqLCVncaul+YtfO94Kw==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.0, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
-        "requested": "[3.5.0, )",
-        "resolved": "3.5.0",
-        "contentHash": "18FUTgaRitsnkT8HQwlJ88fUD2pq2RtLRL5keZajIKhjMutmoYRb3L+1rZO4/tjE6jvIxZuUHh0dB/A0PhK9rA==",
+        "requested": "[3.5.1.6, )",
+        "resolved": "3.5.1.6",
+        "contentHash": "ppSonX+jJo9q24eYpWyB/MsRl/Tdqi9uHZl1wABLQ8nu2Ok2NJpP6i7nKPVpwcT2zZf7mcYMm475rU2MxFhbgw==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.0, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
         }
       },
       "AWSSDK.StepFunctions": {
         "type": "Direct",
-        "requested": "[3.5.0, )",
-        "resolved": "3.5.0",
-        "contentHash": "qYYacB39ZTHjrOD/oqnZW/rL6IDfMP+YRC8z3q1zNRbDhl9eYWwzhGfyEpK3q628yDFyRmPmIntRsTvETFfYEA==",
+        "requested": "[3.5.2.23, )",
+        "resolved": "3.5.2.23",
+        "contentHash": "v84TzkcvbP/fMk9Py2otEkN7wPb6Dz+7Qn4oHFVlX8bYvVvu7/xiXkoUuPmwFI/1mZ/r87LGKzgKofpC9qSr/Q==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.0, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
         }
       },
       "Lambdajection": {
@@ -40,10 +40,28 @@
           "Lambdajection.Generator": "0.5.0"
         }
       },
+      "Lambdajection.Runtime": {
+        "type": "Direct",
+        "requested": "[0.5.0, )",
+        "resolved": "0.5.0",
+        "contentHash": "/L1TVI3jUbE1j7U6ZcMl2j3CBPyr9TqfYVu5jTixVcpHj5x6/L5iWt9ubsjgEvl79dikXvntWb+ouHnZRhSxBA==",
+        "dependencies": {
+          "Amazon.Lambda.RuntimeSupport": "1.2.0"
+        }
+      },
       "Amazon.Lambda.Core": {
         "type": "Transitive",
         "resolved": "1.2.0",
         "contentHash": "goaq1LaH1UJB18BNG/Apxmn0P7dAlLWFbxU2nKxK+M4lH2KJaZDbtlP2gFEAJ+aENOMBHthaLPEtk3944J2OOg=="
+      },
+      "Amazon.Lambda.RuntimeSupport": {
+        "type": "Transitive",
+        "resolved": "1.2.0",
+        "contentHash": "eCNthjnvM5yQnM4KvdvYVd6/gMIJ51T5K0BAQ9GAP0coF4izniFMrRnv2C14qZ/RkssYX5kKN2H3RUxjQlpfmQ==",
+        "dependencies": {
+          "Amazon.Lambda.Core": "1.2.0",
+          "NSwag.MSBuild": "12.0.4"
+        }
       },
       "Amazon.Lambda.Serialization.SystemTextJson": {
         "type": "Transitive",
@@ -55,8 +73,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.0",
-        "contentHash": "bC5slbW3f1QgYlJK/I/zDUlixHq8YzktTwreJHwoOCpnRFB/IHV4EIgdEGwQnWOneJwRfwq4ZB0OhlrM3aT2pw=="
+        "resolved": "3.5.1.34",
+        "contentHash": "U7+LuL8NN20NP+Fg3l9HfH5nuKi+EPxh1zaP1JLg7Twj2OnIf6TuUkJyoTCggJ7mXzfmiLr3YyGu6/MjcvoMrA=="
       },
       "AWSSDK.SecurityToken": {
         "type": "Transitive",
@@ -146,8 +164,7 @@
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
-          "Microsoft.Extensions.Options": "5.0.0",
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
+          "Microsoft.Extensions.Options": "5.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -181,8 +198,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
           "Microsoft.Extensions.Logging.Configuration": "5.0.0",
           "Microsoft.Extensions.Options": "5.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "5.0.0",
-          "System.Text.Json": "5.0.0"
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "5.0.0"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -211,15 +227,10 @@
         "resolved": "5.0.0",
         "contentHash": "cI/VWn9G1fghXrNDagX9nYaaB/nokkZn0HYAawGaELQrl8InSezfe9OnfPZLcJq3esXxygh3hkq2c3qoV3SDyQ=="
       },
-      "System.Diagnostics.DiagnosticSource": {
+      "NSwag.MSBuild": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
+        "resolved": "12.0.4",
+        "contentHash": "4Gqf64I2j3Y5UyxtdvPW4H8h8RgY2e6Cp6++T30/v0aXS9UhErPKg35GKz3nSKRUesjYQh7Duy3cPnDCDdGlMg=="
       },
       "awsutils.common": {
         "type": "Project",
@@ -238,6 +249,8 @@
           "AwsUtils.Common": "1.0.0"
         }
       }
-    }
+    },
+    ".NETCoreApp,Version=v5.0/linux-x64": {},
+    ".NETCoreApp,Version=v5.0/osx-x64": {}
   }
 }

--- a/src/Core/Core.template.yml
+++ b/src/Core/Core.template.yml
@@ -613,10 +613,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: ApprovalNotification::Cythral.CloudFormation.ApprovalNotification.Handler::Run
-      Runtime: dotnetcore3.1
+      Runtime: provided.al2
       Timeout: 30
       MemorySize: 256
-      CodeUri: ../../bin/ApprovalNotification/Release/netcoreapp3.1/publish/
+      CodeUri: ../../bin/ApprovalNotification/Release/net5.0/linux-x64/publish/
+      Layers:
+        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:3
       Policies:
         - AWSLambdaExecute
         - !Ref ApprovalNotificationPolicy

--- a/tests/Core/packages.lock.json
+++ b/tests/Core/packages.lock.json
@@ -147,10 +147,10 @@
       },
       "AWSSDK.SimpleNotificationService": {
         "type": "Transitive",
-        "resolved": "3.5.0",
-        "contentHash": "18FUTgaRitsnkT8HQwlJ88fUD2pq2RtLRL5keZajIKhjMutmoYRb3L+1rZO4/tjE6jvIxZuUHh0dB/A0PhK9rA==",
+        "resolved": "3.5.1.6",
+        "contentHash": "ppSonX+jJo9q24eYpWyB/MsRl/Tdqi9uHZl1wABLQ8nu2Ok2NJpP6i7nKPVpwcT2zZf7mcYMm475rU2MxFhbgw==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.0, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
         }
       },
       "AWSSDK.SQS": {
@@ -1297,11 +1297,12 @@
       "approvalnotification": {
         "type": "Project",
         "dependencies": {
-          "AWSSDK.S3": "3.5.0",
-          "AWSSDK.SimpleNotificationService": "3.5.0",
-          "AWSSDK.StepFunctions": "3.5.0",
+          "AWSSDK.S3": "3.5.4",
+          "AWSSDK.SimpleNotificationService": "3.5.1.6",
+          "AWSSDK.StepFunctions": "3.5.2.23",
           "Common": "1.0.0",
           "Lambdajection": "0.5.0",
+          "Lambdajection.Runtime": "0.5.0",
           "SimpleStorageService": "1.0.0"
         }
       },


### PR DESCRIPTION
This upgrades the approval notification function to use .NET 5 and the Lambdajection.Runtime package. 