### PR TITLE
Common Ref Event Property

### DIFF
--- a/src/Core/GithubWebhook/Github/Entities/PullRequestHead.cs
+++ b/src/Core/GithubWebhook/Github/Entities/PullRequestHead.cs
@@ -7,5 +7,7 @@ namespace Cythral.CloudFormation.GithubWebhook.Github.Entities
         [JsonPropertyName("sha")]
         public string Sha { get; set; }
 
+        [JsonPropertyName("ref")]
+        public string Ref { get; set; }
     }
 }

--- a/src/Core/GithubWebhook/Github/PullRequestEvent.cs
+++ b/src/Core/GithubWebhook/Github/PullRequestEvent.cs
@@ -16,5 +16,8 @@ namespace Cythral.CloudFormation.GithubWebhook.Github
 
         [JsonPropertyName("head_commit_id")]
         public override string HeadCommitId => PullRequest?.Head?.Sha;
+
+        [JsonPropertyName("ref")]
+        public string Ref => $"refs/heads/{PullRequest?.Head?.Ref}";
     }
 }


### PR DESCRIPTION
This makes accessing the ref property the same across push and pull request events. (access via $.ref)