### PR TITLE
Bump Lambdajection + Use Layer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <LambdajectionVersion>0.5.0</LambdajectionVersion>
+        <LambdajectionVersion>0.6.0-beta3</LambdajectionVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Core/ApprovalNotification/Handler.cs
+++ b/src/Core/ApprovalNotification/Handler.cs
@@ -50,7 +50,7 @@ namespace Cythral.CloudFormation.ApprovalNotification
             this.logger = logger;
         }
 
-        public async Task<Response> Handle(Request request, ILambdaContext context = null)
+        public async Task<Response> Handle(Request request)
         {
             logger.LogDebug($"Received request: {Serialize(request)}");
             await approvalCanceler.CancelPreviousApprovalsForPipeline(request.Pipeline);

--- a/src/Core/ApprovalNotification/packages.lock.json
+++ b/src/Core/ApprovalNotification/packages.lock.json
@@ -44,29 +44,29 @@
       },
       "Lambdajection": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Lambdajection.Encryption": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "ZaV/FgWEH8OU5cVZAnsn5Z8Y0jzFnGY9oHkNaaM/sKz+Bzxi622mFTOCfqyp3jnhYUAA4+9RsqgyE1qahQXHFQ==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "PISurDK8wv7WOmRXLZQceYYWEQGSo5VlzSpN8nWNXjbtsV/DXyGAGXU4z0R3Od0xKoT5qv1OFw7ogLgE/nZ4SQ==",
         "dependencies": {
-          "AWSSDK.KeyManagementService": "3.5.0.36"
+          "AWSSDK.KeyManagementService": "3.5.0.42"
         }
       },
       "Lambdajection.Runtime": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "/L1TVI3jUbE1j7U6ZcMl2j3CBPyr9TqfYVu5jTixVcpHj5x6/L5iWt9ubsjgEvl79dikXvntWb+ouHnZRhSxBA==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "YmpyWYfMQqF0a4A0OuYDpFyUvoV85X+MAREeAaxQ1j+244p04K9QaHabzvTjGzrTlW+KN172U4nP6wycWZFfJQ==",
         "dependencies": {
           "Amazon.Lambda.RuntimeSupport": "1.2.0"
         }
@@ -95,15 +95,15 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.1.34",
-        "contentHash": "U7+LuL8NN20NP+Fg3l9HfH5nuKi+EPxh1zaP1JLg7Twj2OnIf6TuUkJyoTCggJ7mXzfmiLr3YyGu6/MjcvoMrA=="
+        "resolved": "3.5.1.42",
+        "contentHash": "X4JXKzpJNp6jOO34Hdpcow/scx3weQsssgCuj1GGdDpMWwOptlobOw/yrUNYrqoP315Gep7QRX5qnA9b9tf5fw=="
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",
-        "resolved": "3.5.0.36",
-        "contentHash": "I1GFu123/0+WRDyCT3OiUZRraCtQLQXWw5nr8tAG7s9aa3/CS+X26BW+gcynTiRf4we72nkwLI2K0uD4zmpenw==",
+        "resolved": "3.5.0.42",
+        "contentHash": "/Q+tphYUiG5WmAn0n+2lVv6een0uzvxEB63PGjNDEzeKNpoPn6kt5cCtvUhQ+Ni7rCeKmbLTEG5DI1j8um9NyQ==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.42, 3.6.0)"
         }
       },
       "AWSSDK.SecurityToken": {
@@ -116,17 +116,17 @@
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -136,8 +136,8 @@
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Core/GithubWebhook/GithubWebhook.csproj
+++ b/src/Core/GithubWebhook/GithubWebhook.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Lambdajection" Version="$(LambdajectionVersion)" />
     <PackageReference Include="Lambdajection.Encryption" Version="$(LambdajectionVersion)" />
     <PackageReference Include="Lambdajection.Runtime" Version="$(LambdajectionVersion)" />
+    <PackageReference Include="Lambdajection.Layer" Version="$(LambdajectionVersion)" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Core/GithubWebhook/Handler.cs
+++ b/src/Core/GithubWebhook/Handler.cs
@@ -63,7 +63,7 @@ namespace Cythral.CloudFormation.GithubWebhook
         /// <param name="context">The lambda context</param>
         /// <returns>A load balancer response object</returns>
 
-        public async Task<ApplicationLoadBalancerResponse> Handle(ApplicationLoadBalancerRequest request, ILambdaContext context = null)
+        public async Task<ApplicationLoadBalancerResponse> Handle(ApplicationLoadBalancerRequest request)
         {
             GithubEvent payload = null;
 

--- a/src/Core/GithubWebhook/packages.lock.json
+++ b/src/Core/GithubWebhook/packages.lock.json
@@ -46,29 +46,35 @@
       },
       "Lambdajection": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Lambdajection.Encryption": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "ZaV/FgWEH8OU5cVZAnsn5Z8Y0jzFnGY9oHkNaaM/sKz+Bzxi622mFTOCfqyp3jnhYUAA4+9RsqgyE1qahQXHFQ==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "PISurDK8wv7WOmRXLZQceYYWEQGSo5VlzSpN8nWNXjbtsV/DXyGAGXU4z0R3Od0xKoT5qv1OFw7ogLgE/nZ4SQ==",
         "dependencies": {
-          "AWSSDK.KeyManagementService": "3.5.0.36"
+          "AWSSDK.KeyManagementService": "3.5.0.42"
         }
+      },
+      "Lambdajection.Layer": {
+        "type": "Direct",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "dEFGFDxzOgPPYgDwerxfJx5rx20/wxg4hADhjO76OsFlut0HR5XNLn3tPmNELIqX9wkaoq//xBn6l0LJ6iSUBA=="
       },
       "Lambdajection.Runtime": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "/L1TVI3jUbE1j7U6ZcMl2j3CBPyr9TqfYVu5jTixVcpHj5x6/L5iWt9ubsjgEvl79dikXvntWb+ouHnZRhSxBA==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "YmpyWYfMQqF0a4A0OuYDpFyUvoV85X+MAREeAaxQ1j+244p04K9QaHabzvTjGzrTlW+KN172U4nP6wycWZFfJQ==",
         "dependencies": {
           "Amazon.Lambda.RuntimeSupport": "1.2.0"
         }
@@ -103,30 +109,30 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.1.34",
-        "contentHash": "U7+LuL8NN20NP+Fg3l9HfH5nuKi+EPxh1zaP1JLg7Twj2OnIf6TuUkJyoTCggJ7mXzfmiLr3YyGu6/MjcvoMrA=="
+        "resolved": "3.5.1.42",
+        "contentHash": "X4JXKzpJNp6jOO34Hdpcow/scx3weQsssgCuj1GGdDpMWwOptlobOw/yrUNYrqoP315Gep7QRX5qnA9b9tf5fw=="
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",
-        "resolved": "3.5.0.36",
-        "contentHash": "I1GFu123/0+WRDyCT3OiUZRraCtQLQXWw5nr8tAG7s9aa3/CS+X26BW+gcynTiRf4we72nkwLI2K0uD4zmpenw==",
+        "resolved": "3.5.0.42",
+        "contentHash": "/Q+tphYUiG5WmAn0n+2lVv6een0uzvxEB63PGjNDEzeKNpoPn6kt5cCtvUhQ+Ni7rCeKmbLTEG5DI1j8um9NyQ==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.42, 3.6.0)"
         }
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -136,8 +142,8 @@
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Core/S3Deployment/Handler.cs
+++ b/src/Core/S3Deployment/Handler.cs
@@ -49,7 +49,7 @@ namespace Cythral.CloudFormation.S3Deployment
             this.logger = logger;
         }
 
-        public async Task<object> Handle(Request request, ILambdaContext context = null)
+        public async Task<object> Handle(Request request)
         {
             await githubStatusNotifier.NotifyPending(
                 bucketName: request.DestinationBucket,

--- a/src/Core/S3Deployment/packages.lock.json
+++ b/src/Core/S3Deployment/packages.lock.json
@@ -22,29 +22,29 @@
       },
       "Lambdajection": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Lambdajection.Encryption": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "ZaV/FgWEH8OU5cVZAnsn5Z8Y0jzFnGY9oHkNaaM/sKz+Bzxi622mFTOCfqyp3jnhYUAA4+9RsqgyE1qahQXHFQ==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "PISurDK8wv7WOmRXLZQceYYWEQGSo5VlzSpN8nWNXjbtsV/DXyGAGXU4z0R3Od0xKoT5qv1OFw7ogLgE/nZ4SQ==",
         "dependencies": {
-          "AWSSDK.KeyManagementService": "3.5.0.36"
+          "AWSSDK.KeyManagementService": "3.5.0.42"
         }
       },
       "Lambdajection.Runtime": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "/L1TVI3jUbE1j7U6ZcMl2j3CBPyr9TqfYVu5jTixVcpHj5x6/L5iWt9ubsjgEvl79dikXvntWb+ouHnZRhSxBA==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "YmpyWYfMQqF0a4A0OuYDpFyUvoV85X+MAREeAaxQ1j+244p04K9QaHabzvTjGzrTlW+KN172U4nP6wycWZFfJQ==",
         "dependencies": {
           "Amazon.Lambda.RuntimeSupport": "1.2.0"
         }
@@ -84,25 +84,25 @@
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",
-        "resolved": "3.5.0.36",
-        "contentHash": "I1GFu123/0+WRDyCT3OiUZRraCtQLQXWw5nr8tAG7s9aa3/CS+X26BW+gcynTiRf4we72nkwLI2K0uD4zmpenw==",
+        "resolved": "3.5.0.42",
+        "contentHash": "/Q+tphYUiG5WmAn0n+2lVv6een0uzvxEB63PGjNDEzeKNpoPn6kt5cCtvUhQ+Ni7rCeKmbLTEG5DI1j8um9NyQ==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.42, 3.6.0)"
         }
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -112,8 +112,8 @@
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Core/S3TagOutdatedArtifacts/Handler.cs
+++ b/src/Core/S3TagOutdatedArtifacts/Handler.cs
@@ -42,7 +42,7 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts
             this.getObject = getObject;
         }
 
-        public async Task<bool> Handle(Request request, ILambdaContext context)
+        public async Task<bool> Handle(Request request)
         {
             manifest = await getObject.GetZipEntryInObject<Manifest>(request.ManifestLocation, request.ManifestFilename);
 

--- a/src/Core/S3TagOutdatedArtifacts/packages.lock.json
+++ b/src/Core/S3TagOutdatedArtifacts/packages.lock.json
@@ -22,13 +22,13 @@
       },
       "Lambdajection": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Amazon.Lambda.Core": {
@@ -51,17 +51,17 @@
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -71,8 +71,8 @@
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Core/StackDeployment/Handler.cs
+++ b/src/Core/StackDeployment/Handler.cs
@@ -61,10 +61,7 @@ namespace Cythral.CloudFormation.StackDeployment
             this.config = config.Value;
         }
 
-        public async Task<Response> Handle(
-            SQSEvent sqsEvent,
-            ILambdaContext context = null
-        )
+        public async Task<Response> Handle(SQSEvent sqsEvent)
         {
             var request = requestFactory.CreateFromSqsEvent(sqsEvent);
             var owner = request.CommitInfo.GithubOwner;

--- a/src/Core/StackDeployment/packages.lock.json
+++ b/src/Core/StackDeployment/packages.lock.json
@@ -46,22 +46,22 @@
       },
       "Lambdajection": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Lambdajection.Encryption": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "ZaV/FgWEH8OU5cVZAnsn5Z8Y0jzFnGY9oHkNaaM/sKz+Bzxi622mFTOCfqyp3jnhYUAA4+9RsqgyE1qahQXHFQ==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "PISurDK8wv7WOmRXLZQceYYWEQGSo5VlzSpN8nWNXjbtsV/DXyGAGXU4z0R3Od0xKoT5qv1OFw7ogLgE/nZ4SQ==",
         "dependencies": {
-          "AWSSDK.KeyManagementService": "3.5.0.36"
+          "AWSSDK.KeyManagementService": "3.5.0.42"
         }
       },
       "System.Net.Http.Json": {
@@ -88,30 +88,30 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.1.34",
-        "contentHash": "U7+LuL8NN20NP+Fg3l9HfH5nuKi+EPxh1zaP1JLg7Twj2OnIf6TuUkJyoTCggJ7mXzfmiLr3YyGu6/MjcvoMrA=="
+        "resolved": "3.5.1.42",
+        "contentHash": "X4JXKzpJNp6jOO34Hdpcow/scx3weQsssgCuj1GGdDpMWwOptlobOw/yrUNYrqoP315Gep7QRX5qnA9b9tf5fw=="
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",
-        "resolved": "3.5.0.36",
-        "contentHash": "I1GFu123/0+WRDyCT3OiUZRraCtQLQXWw5nr8tAG7s9aa3/CS+X26BW+gcynTiRf4we72nkwLI2K0uD4zmpenw==",
+        "resolved": "3.5.0.42",
+        "contentHash": "/Q+tphYUiG5WmAn0n+2lVv6een0uzvxEB63PGjNDEzeKNpoPn6kt5cCtvUhQ+Ni7rCeKmbLTEG5DI1j8um9NyQ==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.42, 3.6.0)"
         }
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -121,8 +121,8 @@
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Core/StackDeploymentStatus/Handler.cs
+++ b/src/Core/StackDeploymentStatus/Handler.cs
@@ -57,10 +57,7 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
             this.logger = logger;
         }
 
-        public async Task<Response> Handle(
-            SNSEvent snsRequest,
-            ILambdaContext context = null
-        )
+        public async Task<Response> Handle(SNSEvent snsRequest)
         {
             logger.LogInformation($"Received request: {JsonSerializer.Serialize(snsRequest)}");
 

--- a/src/Core/StackDeploymentStatus/packages.lock.json
+++ b/src/Core/StackDeploymentStatus/packages.lock.json
@@ -55,22 +55,22 @@
       },
       "Lambdajection": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Lambdajection.Encryption": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "ZaV/FgWEH8OU5cVZAnsn5Z8Y0jzFnGY9oHkNaaM/sKz+Bzxi622mFTOCfqyp3jnhYUAA4+9RsqgyE1qahQXHFQ==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "PISurDK8wv7WOmRXLZQceYYWEQGSo5VlzSpN8nWNXjbtsV/DXyGAGXU4z0R3Od0xKoT5qv1OFw7ogLgE/nZ4SQ==",
         "dependencies": {
-          "AWSSDK.KeyManagementService": "3.5.0.36"
+          "AWSSDK.KeyManagementService": "3.5.0.42"
         }
       },
       "System.Net.Http.Json": {
@@ -97,30 +97,30 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.1.34",
-        "contentHash": "U7+LuL8NN20NP+Fg3l9HfH5nuKi+EPxh1zaP1JLg7Twj2OnIf6TuUkJyoTCggJ7mXzfmiLr3YyGu6/MjcvoMrA=="
+        "resolved": "3.5.1.42",
+        "contentHash": "X4JXKzpJNp6jOO34Hdpcow/scx3weQsssgCuj1GGdDpMWwOptlobOw/yrUNYrqoP315Gep7QRX5qnA9b9tf5fw=="
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",
-        "resolved": "3.5.0.36",
-        "contentHash": "I1GFu123/0+WRDyCT3OiUZRraCtQLQXWw5nr8tAG7s9aa3/CS+X26BW+gcynTiRf4we72nkwLI2K0uD4zmpenw==",
+        "resolved": "3.5.0.42",
+        "contentHash": "/Q+tphYUiG5WmAn0n+2lVv6een0uzvxEB63PGjNDEzeKNpoPn6kt5cCtvUhQ+Ni7rCeKmbLTEG5DI1j8um9NyQ==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.42, 3.6.0)"
         }
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -130,8 +130,8 @@
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Core/UpdateTargets/Handler.cs
+++ b/src/Core/UpdateTargets/Handler.cs
@@ -40,10 +40,7 @@ namespace Cythral.CloudFormation.UpdateTargets
             this.logger = logger;
         }
 
-        public async Task<Response> Handle(
-            SNSEvent snsRequest,
-            ILambdaContext context = null
-        )
+        public async Task<Response> Handle(SNSEvent snsRequest)
         {
             var request = requestFactory.CreateFromSnsEvent(snsRequest);
             logger.LogInformation($"Received transformed request: {JsonSerializer.Serialize(request)}");

--- a/src/Core/UpdateTargets/packages.lock.json
+++ b/src/Core/UpdateTargets/packages.lock.json
@@ -19,13 +19,13 @@
       },
       "Lambdajection": {
         "type": "Direct",
-        "requested": "[0.5.0, )",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "requested": "[0.6.0-beta3, )",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Amazon.Lambda.Core": {
@@ -48,17 +48,17 @@
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -68,8 +68,8 @@
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/tests/Core/S3TagOutdatedArtifacts/HandlerTests.cs
+++ b/tests/Core/S3TagOutdatedArtifacts/HandlerTests.cs
@@ -51,7 +51,6 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
         {
             var getObject = Substitute.For<S3GetObjectFacade>();
             var s3Client = Substitute.For<IAmazonS3>();
-            var context = Substitute.For<ILambdaContext>();
 
             getObject.GetZipEntryInObject<Manifest>(Any<string>(), Any<string>()).Returns(manifest);
             s3Client.ListObjectsV2Async(Any<ListObjectsV2Request>()).Returns(new ListObjectsV2Response
@@ -63,7 +62,7 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
             });
 
             var handler = new Handler(s3Client, getObject);
-            await handler.Handle(request, context);
+            await handler.Handle(request);
 
             await getObject.Received().GetZipEntryInObject<Manifest>(Is(manifestLocation), Is(manifestFilename));
         }
@@ -73,7 +72,6 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
         {
             var getObject = Substitute.For<S3GetObjectFacade>();
             var s3Client = Substitute.For<IAmazonS3>();
-            var context = Substitute.For<ILambdaContext>();
 
             getObject.GetZipEntryInObject<Manifest>(Any<string>(), Any<string>()).Returns(manifest);
             s3Client.ListObjectsV2Async(Any<ListObjectsV2Request>()).Returns(new ListObjectsV2Response
@@ -85,7 +83,7 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
             });
 
             var handler = new Handler(s3Client, getObject);
-            await handler.Handle(request, context);
+            await handler.Handle(request);
 
             await s3Client.Received().ListObjectsV2Async(Is<ListObjectsV2Request>(request =>
                 request.BucketName == bucketName &&
@@ -98,7 +96,6 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
         {
             var getObject = Substitute.For<S3GetObjectFacade>();
             var s3Client = Substitute.For<IAmazonS3>();
-            var context = Substitute.For<ILambdaContext>();
 
             getObject.GetZipEntryInObject<Manifest>(Any<string>(), Any<string>()).Returns(manifest);
             s3Client.ListObjectsV2Async(Any<ListObjectsV2Request>()).Returns(new ListObjectsV2Response
@@ -110,7 +107,7 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
             });
 
             var handler = new Handler(s3Client, getObject);
-            await handler.Handle(request, context);
+            await handler.Handle(request);
 
             await s3Client.Received().PutObjectTaggingAsync(Is<PutObjectTaggingRequest>(request =>
                 request.BucketName == manifest.BucketName &&
@@ -124,7 +121,6 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
         {
             var getObject = Substitute.For<S3GetObjectFacade>();
             var s3Client = Substitute.For<IAmazonS3>();
-            var context = Substitute.For<ILambdaContext>();
 
             getObject.GetZipEntryInObject<Manifest>(Any<string>(), Any<string>()).Returns(manifest);
             s3Client.ListObjectsV2Async(Any<ListObjectsV2Request>()).Returns(new ListObjectsV2Response
@@ -135,7 +131,7 @@ namespace Cythral.CloudFormation.S3TagOutdatedArtifacts.Tests
                 }
             });
             var handler = new Handler(s3Client, getObject);
-            await handler.Handle(request, context);
+            await handler.Handle(request);
 
             await s3Client.Received().PutObjectTaggingAsync(Is<PutObjectTaggingRequest>(request =>
                 request.BucketName == manifest.BucketName &&

--- a/tests/Core/packages.lock.json
+++ b/tests/Core/packages.lock.json
@@ -123,10 +123,10 @@
       },
       "AWSSDK.KeyManagementService": {
         "type": "Transitive",
-        "resolved": "3.5.0.36",
-        "contentHash": "I1GFu123/0+WRDyCT3OiUZRraCtQLQXWw5nr8tAG7s9aa3/CS+X26BW+gcynTiRf4we72nkwLI2K0uD4zmpenw==",
+        "resolved": "3.5.0.42",
+        "contentHash": "/Q+tphYUiG5WmAn0n+2lVv6een0uzvxEB63PGjNDEzeKNpoPn6kt5cCtvUhQ+Ni7rCeKmbLTEG5DI1j8um9NyQ==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.1.34, 3.6.0)"
+          "AWSSDK.Core": "[3.5.1.42, 3.6.0)"
         }
       },
       "AWSSDK.S3": {
@@ -200,27 +200,27 @@
       },
       "Lambdajection": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "IS8YYaO2Ltqd5xOrU4/vcctrLx35vsEtu21QOVHyDYQsmzmp8MLier6VTZyoPUa9WMCDzg4UC8k24TaBuByJTw==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "X+Cjc3mHR38Y/f+XxzrKIpWbwXXMd0qVciOg3KYYhpHwBcRLi/gk1xNDpWg6k4yxHJX5rITxSCnMoEvMIIi9Uw==",
         "dependencies": {
-          "Lambdajection.Attributes": "0.5.0",
-          "Lambdajection.Core": "0.5.0",
-          "Lambdajection.Generator": "0.5.0"
+          "Lambdajection.Attributes": "0.6.0-beta3",
+          "Lambdajection.Core": "0.6.0-beta3",
+          "Lambdajection.Generator": "0.6.0-beta3"
         }
       },
       "Lambdajection.Attributes": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "0GfCW/beW6O3+UHnahQwgmcwcKOFkHB3H0QQfyYyff+iTL0XqRzsH83boutgzV0n/xuOjrJDZj3bDWDzTp5T3w=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "FHSHE7WqyovEHrpuR6dI9St22u7Hi/FY8UR0timtc9EPtAwXs9bNnBVOa7x8SM75r1ZT+qeNlybcp0tvXnLJuQ=="
       },
       "Lambdajection.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "lgwXBvTPabPvrpnvGvxJQSobqZK4sS0bpp3zi8T6ryREkHhMcuEHUTCiE+382IYa66AUSKqr5xqX66q2TGfUdg==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "wrkPt31Y2P8u10tAnbfwedCVAs2j1mIaMXgsonns1DDTXCfCIgoPLPdB/y80ZEd6Ep5SsxCOqgVXwRJTSlZBGQ==",
         "dependencies": {
           "Amazon.Lambda.Core": "1.2.0",
           "Amazon.Lambda.Serialization.SystemTextJson": "2.1.0",
-          "Lambdajection.Attributes": "0.5.0",
+          "Lambdajection.Attributes": "0.6.0-beta3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "5.0.0",
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
@@ -230,21 +230,26 @@
       },
       "Lambdajection.Encryption": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "ZaV/FgWEH8OU5cVZAnsn5Z8Y0jzFnGY9oHkNaaM/sKz+Bzxi622mFTOCfqyp3jnhYUAA4+9RsqgyE1qahQXHFQ==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "PISurDK8wv7WOmRXLZQceYYWEQGSo5VlzSpN8nWNXjbtsV/DXyGAGXU4z0R3Od0xKoT5qv1OFw7ogLgE/nZ4SQ==",
         "dependencies": {
-          "AWSSDK.KeyManagementService": "3.5.0.36"
+          "AWSSDK.KeyManagementService": "3.5.0.42"
         }
       },
       "Lambdajection.Generator": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "NiAXlnAw8dGWXlArTryCIPTDOg3MzOUyXt9loaagvvuYPG2S9vRNOo08JYygPMfLttrFruanOfBcD9u80i5Z4g=="
+        "resolved": "0.6.0-beta3",
+        "contentHash": "4mWDRDLHVfB0q49zlFeGgsaq7o35DLKDfe20jr6Gpd0F9ku1zdySlRCkJawKxxPbKUhGT3EFWlSCzUH5/7wobw=="
+      },
+      "Lambdajection.Layer": {
+        "type": "Transitive",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "dEFGFDxzOgPPYgDwerxfJx5rx20/wxg4hADhjO76OsFlut0HR5XNLn3tPmNELIqX9wkaoq//xBn6l0LJ6iSUBA=="
       },
       "Lambdajection.Runtime": {
         "type": "Transitive",
-        "resolved": "0.5.0",
-        "contentHash": "/L1TVI3jUbE1j7U6ZcMl2j3CBPyr9TqfYVu5jTixVcpHj5x6/L5iWt9ubsjgEvl79dikXvntWb+ouHnZRhSxBA==",
+        "resolved": "0.6.0-beta3",
+        "contentHash": "YmpyWYfMQqF0a4A0OuYDpFyUvoV85X+MAREeAaxQ1j+244p04K9QaHabzvTjGzrTlW+KN172U4nP6wycWZFfJQ==",
         "dependencies": {
           "Amazon.Lambda.RuntimeSupport": "1.2.0"
         }
@@ -1324,9 +1329,9 @@
           "AWSSDK.SimpleNotificationService": "3.5.1.6",
           "AWSSDK.StepFunctions": "3.5.2.23",
           "Brighid.Identity.Client": "0.1.24",
-          "Lambdajection": "0.5.0",
-          "Lambdajection.Encryption": "0.5.0",
-          "Lambdajection.Runtime": "0.5.0",
+          "Lambdajection": "0.6.0-beta3",
+          "Lambdajection.Encryption": "0.6.0-beta3",
+          "Lambdajection.Runtime": "0.6.0-beta3",
           "SimpleStorageService": "1.0.0"
         }
       },
@@ -1392,9 +1397,10 @@
           "AWSSDK.StepFunctions": "3.5.2.23",
           "Amazon.Lambda.ApplicationLoadBalancerEvents": "2.1.0",
           "CloudFormation": "1.0.0",
-          "Lambdajection": "0.5.0",
-          "Lambdajection.Encryption": "0.5.0",
-          "Lambdajection.Runtime": "0.5.0",
+          "Lambdajection": "0.6.0-beta3",
+          "Lambdajection.Encryption": "0.6.0-beta3",
+          "Lambdajection.Layer": "0.6.0-beta3",
+          "Lambdajection.Runtime": "0.6.0-beta3",
           "System.Net.Http.Json": "5.0.0"
         }
       },
@@ -1412,9 +1418,9 @@
           "AWSSDK.SecurityToken": "3.5.1.22",
           "AwsUtils.Common": "1.0.0",
           "GithubUtils": "1.0.0",
-          "Lambdajection": "0.5.0",
-          "Lambdajection.Encryption": "0.5.0",
-          "Lambdajection.Runtime": "0.5.0",
+          "Lambdajection": "0.6.0-beta3",
+          "Lambdajection.Encryption": "0.6.0-beta3",
+          "Lambdajection.Runtime": "0.6.0-beta3",
           "Octokit": "0.47.0",
           "SimpleStorageService": "1.0.0"
         }
@@ -1424,7 +1430,7 @@
         "dependencies": {
           "AWSSDK.S3": "3.5.0",
           "AWSSDK.SecurityToken": "3.5.0",
-          "Lambdajection": "0.5.0",
+          "Lambdajection": "0.6.0-beta3",
           "SimpleStorageService": "1.0.0"
         }
       },
@@ -1443,8 +1449,8 @@
           "AWSSDK.SecurityToken": "3.5.0",
           "AWSSDK.StepFunctions": "3.5.0",
           "Amazon.Lambda.SQSEvents": "1.1.0",
-          "Lambdajection": "0.5.0",
-          "Lambdajection.Encryption": "0.5.0",
+          "Lambdajection": "0.6.0-beta3",
+          "Lambdajection.Encryption": "0.6.0-beta3",
           "System.Net.Http.Json": "3.2.1"
         }
       },
@@ -1457,8 +1463,8 @@
           "AWSSDK.SecurityToken": "3.5.0",
           "AWSSDK.StepFunctions": "3.5.0",
           "Amazon.Lambda.SNSEvents": "1.1.0",
-          "Lambdajection": "0.5.0",
-          "Lambdajection.Encryption": "0.5.0",
+          "Lambdajection": "0.6.0-beta3",
+          "Lambdajection.Encryption": "0.6.0-beta3",
           "System.Net.Http.Json": "3.2.1"
         }
       },
@@ -1467,7 +1473,7 @@
         "dependencies": {
           "AWSSDK.ElasticLoadBalancingV2": "3.5.0",
           "Amazon.Lambda.SNSEvents": "1.1.0",
-          "Lambdajection": "0.5.0"
+          "Lambdajection": "0.6.0-beta3"
         }
       }
     }


### PR DESCRIPTION
This bumps lambdajection to v0.6.0-beta3 and utilizes the new layer in the Github Webhook. 