### PR TITLE
CYTHINF-213 Upgrade to .NET 5.0.101

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "5.0.101"
   },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "2.1.1"

--- a/src/Core/Core.template.yml
+++ b/src/Core/Core.template.yml
@@ -337,7 +337,7 @@ Resources:
       CodeUri: ../../bin/GithubWebhook/Release/net5.0/linux-x64/publish/
       MemorySize: 512
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:3
+        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:6
         - !Ref LambdajectionLayerArn
       Policies:
         - AWSLambdaExecute
@@ -652,7 +652,7 @@ Resources:
       MemorySize: 256
       CodeUri: ../../bin/ApprovalNotification/Release/net5.0/linux-x64/publish/
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:3
+        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:6
       Policies:
         - AWSLambdaExecute
         - !Ref ApprovalNotificationPolicy
@@ -770,7 +770,7 @@ Resources:
       MemorySize: 256
       CodeUri: ../../bin/S3Deployment/Release/net5.0/linux-x64/publish/
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:3
+        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:net5:6
       Role: !ImportValue cfn-utilities:MasterRoleArn
       Environment:
         Variables:


### PR DESCRIPTION
This upgrades the project to use .NET SDK 5.0.101.  Lambdas dependent on the dotnet-lambda-layer have been updated to use its new version containing 5.0.1 runtime dependencies.