### PR TITLE
Include Ref in Execution Names

### DIFF
--- a/src/Core/GithubWebhook/Github/GithubEvent.cs
+++ b/src/Core/GithubWebhook/Github/GithubEvent.cs
@@ -16,5 +16,8 @@ namespace Cythral.CloudFormation.GithubWebhook.Github
 
         [JsonPropertyName("head_commit_id")]
         public abstract string HeadCommitId { get; }
+
+        [JsonPropertyName("ref")]
+        public abstract string Ref { get; set; }
     }
 }

--- a/src/Core/GithubWebhook/Github/PullRequestEvent.cs
+++ b/src/Core/GithubWebhook/Github/PullRequestEvent.cs
@@ -18,6 +18,10 @@ namespace Cythral.CloudFormation.GithubWebhook.Github
         public override string HeadCommitId => PullRequest?.Head?.Sha;
 
         [JsonPropertyName("ref")]
-        public string Ref => $"refs/heads/{PullRequest?.Head?.Ref}";
+        public override string Ref
+        {
+            get => $"refs/heads/{PullRequest?.Head?.Ref}";
+            set => _ = value;
+        }
     }
 }

--- a/src/Core/GithubWebhook/Github/PushEvent.cs
+++ b/src/Core/GithubWebhook/Github/PushEvent.cs
@@ -9,7 +9,7 @@ namespace Cythral.CloudFormation.GithubWebhook.Github
     public class PushEvent : GithubEvent
     {
         [JsonPropertyName("ref")]
-        public string Ref { get; set; }
+        public override string Ref { get; set; }
 
         [JsonPropertyName("head")]
         public string Head { get; set; }

--- a/src/Core/GithubWebhook/Pipelines/PipelineStarter.cs
+++ b/src/Core/GithubWebhook/Pipelines/PipelineStarter.cs
@@ -42,7 +42,7 @@ namespace Cythral.CloudFormation.GithubWebhook.Pipelines
                 var response = await stepFunctionsClient.StartExecutionAsync(new StartExecutionRequest
                 {
                     StateMachineArn = $"arn:aws:states:{region}:{accountId}:stateMachine:{payload.Repository.Name}-cicd-pipeline",
-                    Name = payload.HeadCommitId,
+                    Name = $"{payload.Ref}@{payload.HeadCommitId}",
                     Input = input
                 });
 

--- a/tests/Core/GithubWebhook/Pipelines/PipelineStarterTests.cs
+++ b/tests/Core/GithubWebhook/Pipelines/PipelineStarterTests.cs
@@ -33,8 +33,10 @@ namespace Cythral.CloudFormation.GithubWebhook.Pipelines.Tests
         {
             var repoName = "name";
             var sha = "sha";
+            var @ref = "ref";
             var payload = new PushEvent
             {
+                Ref = @ref,
                 HeadCommit = new Commit
                 {
                     Id = sha,
@@ -54,7 +56,7 @@ namespace Cythral.CloudFormation.GithubWebhook.Pipelines.Tests
             var StateMachineArn = $"arn:aws:states:us-east-1:5:stateMachine:{repoName}-cicd-pipeline";
             await stepFunctionsClient.Received().StartExecutionAsync(Arg.Is<StartExecutionRequest>(req =>
                 req.StateMachineArn == StateMachineArn &&
-                req.Name == sha &&
+                req.Name == $"{@ref}@{sha}" &&
                 req.Input == serializedPayload
             ));
         }
@@ -64,13 +66,15 @@ namespace Cythral.CloudFormation.GithubWebhook.Pipelines.Tests
         {
             var repoName = "name";
             var sha = "sha";
+            var @ref = "ref";
             var payload = new PullRequestEvent
             {
                 PullRequest = new PullRequest
                 {
                     Head = new PullRequestHead
                     {
-                        Sha = sha
+                        Sha = sha,
+                        Ref = @ref,
                     }
                 },
                 Repository = new Repository
@@ -89,7 +93,7 @@ namespace Cythral.CloudFormation.GithubWebhook.Pipelines.Tests
             var StateMachineArn = $"arn:aws:states:us-east-1:5:stateMachine:{repoName}-cicd-pipeline";
             await stepFunctionsClient.Received().StartExecutionAsync(Arg.Is<StartExecutionRequest>(req =>
                 req.StateMachineArn == StateMachineArn &&
-                req.Name == sha &&
+                req.Name == $"refs/heads/{@ref}@{sha}" &&
                 req.Input == serializedPayload
             ));
         }


### PR DESCRIPTION
Include ref names in execution names so that builds can happen off of tags. 