### PR TITLE
CYTHINF-214 Fix Outdated Stack Outputs

### DIFF
--- a/src/Core/StackDeploymentStatus/Startup.cs
+++ b/src/Core/StackDeploymentStatus/Startup.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 using Amazon.CloudFormation;
 using Amazon.S3;
 using Amazon.SQS;
@@ -26,6 +28,7 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
             services.AddSingleton<GithubStatusNotifier>();
             services.AddSingleton<TokenInfoRepository>();
             services.AddSingleton<StackDeploymentStatusRequestFactory>();
+            services.AddSingleton<Wait>(Task.Delay);
         }
     }
 }

--- a/tests/Core/StackDeploymentStatus/HandlerTests.cs
+++ b/tests/Core/StackDeploymentStatus/HandlerTests.cs
@@ -170,9 +170,10 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
+            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
 
             await handler.Handle(snsEvent);
 
@@ -197,8 +198,9 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
             var config = CreateConfig();
+            var wait = Substitute.For<Wait>();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
 
             await handler.Handle(snsEvent);
 
@@ -235,9 +237,10 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
+            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
 
             request.SourceTopic = githubTopicArn;
 
@@ -274,9 +277,10 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
+            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
 
             await handler.Handle(snsEvent);
 
@@ -319,9 +323,10 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
+            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
 
             request.SourceTopic = githubTopicArn;
 


### PR DESCRIPTION
This fixes an issue where stack outputs are outdated when requested in the stack deployment status function, by adding a second's worth of delay