### PR TITLE
CYTHINF-214 Fix Stack Deployment Status for Stacks with Nested Stacks

### DIFF
--- a/src/Core/StackDeploymentStatus/Handler.cs
+++ b/src/Core/StackDeploymentStatus/Handler.cs
@@ -25,8 +25,6 @@ using Microsoft.Extensions.Options;
 
 namespace Cythral.CloudFormation.StackDeploymentStatus
 {
-    public delegate Task Wait(int ms);
-
     [Lambda(typeof(Startup))]
     public partial class Handler
     {
@@ -36,7 +34,6 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
         private readonly IAwsFactory<IAmazonCloudFormation> cloudformationFactory;
         private readonly GithubStatusNotifier githubStatusNotifier;
         private readonly TokenInfoRepository tokenInfoRepository;
-        private readonly Wait wait;
         private readonly Config config;
         private readonly ILogger<Handler> logger;
 
@@ -47,7 +44,6 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
             IAwsFactory<IAmazonCloudFormation> cloudformationFactory,
             GithubStatusNotifier githubStatusNotifier,
             TokenInfoRepository tokenInfoRepository,
-            Wait wait,
             IOptions<Config> config,
             ILogger<Handler> logger
         )
@@ -58,7 +54,6 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
             this.cloudformationFactory = cloudformationFactory;
             this.tokenInfoRepository = tokenInfoRepository;
             this.githubStatusNotifier = githubStatusNotifier;
-            this.wait = wait;
             this.config = config.Value;
             this.logger = logger;
         }
@@ -140,8 +135,6 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
         private async Task<Dictionary<string, string>> GetStackOutputs(string stackId, string roleArn)
         {
             var client = await cloudformationFactory.Create(roleArn);
-            await wait(1000);
-
             var response = await client.DescribeStacksAsync(new DescribeStacksRequest
             {
                 StackName = stackId

--- a/src/Core/StackDeploymentStatus/Handler.cs
+++ b/src/Core/StackDeploymentStatus/Handler.cs
@@ -65,7 +65,7 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
             var request = requestFactory.CreateFromSnsEvent(snsRequest);
             var status = request.ResourceStatus;
 
-            if (request.ResourceType == "AWS::CloudFormation::Stack" && request.ClientRequestToken.Length > 0)
+            if (request.ClientRequestToken.Length > 0 && request.StackId == request.PhysicalResourceId)
             {
                 if (status == "DELETE_COMPLETE" || status.EndsWith("ROLLBACK_COMPLETE") || status.EndsWith("FAILED"))
                 {

--- a/src/Core/StackDeploymentStatus/Startup.cs
+++ b/src/Core/StackDeploymentStatus/Startup.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 using Amazon.CloudFormation;
 using Amazon.S3;
 using Amazon.SQS;
@@ -28,7 +26,6 @@ namespace Cythral.CloudFormation.StackDeploymentStatus
             services.AddSingleton<GithubStatusNotifier>();
             services.AddSingleton<TokenInfoRepository>();
             services.AddSingleton<StackDeploymentStatusRequestFactory>();
-            services.AddSingleton<Wait>(Task.Delay);
         }
     }
 }

--- a/tests/Core/StackDeploymentStatus/HandlerTests.cs
+++ b/tests/Core/StackDeploymentStatus/HandlerTests.cs
@@ -170,10 +170,9 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
-            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
 
             await handler.Handle(snsEvent);
 
@@ -198,9 +197,8 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
             var config = CreateConfig();
-            var wait = Substitute.For<Wait>();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
 
             await handler.Handle(snsEvent);
 
@@ -237,10 +235,9 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
-            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
 
             request.SourceTopic = githubTopicArn;
 
@@ -277,10 +274,9 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
-            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
 
             await handler.Handle(snsEvent);
 
@@ -323,10 +319,9 @@ namespace Cythral.CloudFormation.Tests.StackDeploymentStatus
             var statusNotifier = CreateStatusNotifier();
             var tokenInfoRepository = CreateTokenInfoRepository();
             var snsEvent = Substitute.For<SNSEvent>();
-            var wait = Substitute.For<Wait>();
             var config = CreateConfig();
             var logger = Substitute.For<ILogger<Handler>>();
-            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, wait, config, logger);
+            var handler = new Handler(requestFactory, stepFunctions, sqs, cloudformationFactory, statusNotifier, tokenInfoRepository, config, logger);
 
             request.SourceTopic = githubTopicArn;
 


### PR DESCRIPTION
Stacks with nested stacks were succeeding/failing prematurely because we were relying on the resource type to determine if we're working on the parent stack or not.  This switches the condition to check if the StackId matches the PhysicalResourceId.